### PR TITLE
Add andy output directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 out/
 output/
 target/
+andy/
 assignments/*/target/
 
 *.class


### PR DESCRIPTION
Added the new output directory `/andy` to `.gitignore`.

https://github.com/cse1110/andy-maven-plugin/pull/2